### PR TITLE
Introduced the flag for Console Log truncation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	
     <groupId>com.inflectra.spiratest.plugins</groupId>
     <artifactId>inflectra-spira-integration</artifactId>
-    <version>3.2.5-SNAPSHOT</version>
+    <version>3.2.6-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
         <jenkins.version>2.7.3</jenkins.version>

--- a/src/main/java/com/inflectra/spiratest/plugins/SpiraBuilder.java
+++ b/src/main/java/com/inflectra/spiratest/plugins/SpiraBuilder.java
@@ -92,6 +92,7 @@ public class SpiraBuilder extends BuildWrapper
         private String username;
         //private String password;
         private Secret password;
+        private boolean truncateConsoleLog;
 
         public boolean isApplicable(Class<? extends AbstractProject> aClass)
         {
@@ -118,6 +119,8 @@ public class SpiraBuilder extends BuildWrapper
 
             //Get the given plain text or encrypted text password out of the form
             password = Secret.fromString(formData.getString("password"));
+
+            truncateConsoleLog = formData.getBoolean("truncate");
 
             // ^Can also use req.bindJSON(this, formData);
             //  (easier when there are many fields; need set* methods for this, like setUseFrench)
@@ -150,6 +153,10 @@ public class SpiraBuilder extends BuildWrapper
             return password;
         }
 
+        public boolean getTruncateConsoleLog(){
+            return truncateConsoleLog;
+        }
+
         public void setPassword(Secret password) {
             this.password = password;
         }
@@ -165,7 +172,7 @@ public class SpiraBuilder extends BuildWrapper
         public FormValidation doTestConnection(
         	    @QueryParameter("url") final String url,
         	    @QueryParameter("username") final String username,
-        	    @QueryParameter("password") final String password)
+                @QueryParameter("password") final String password)
         		throws IOException, ServletException
         {
 	            try
@@ -174,7 +181,6 @@ public class SpiraBuilder extends BuildWrapper
 	            	spiraClient.setUrl(url);
 	            	spiraClient.setUserName(username);
                     spiraClient.setPassword(Secret.fromString(password));
-
 	            	boolean success = spiraClient.testConnection();
 	            	if (success)
 	            	{

--- a/src/main/resources/com/inflectra/spiratest/plugins/SpiraBuilder/global.jelly
+++ b/src/main/resources/com/inflectra/spiratest/plugins/SpiraBuilder/global.jelly
@@ -23,6 +23,9 @@
 	<f:entry title="Password" help="/plugin/inflectra-spira-integration/help-password.html">
 	  <f:password name="password" value="${descriptor.password}" />
 	</f:entry>
+	<f:entry title="Truncate Console Log" help="/plugin/inflectra-spira-integration/help-truncate.html">
+		<f:checkbox name="truncate" checked="${descriptor.truncateConsoleLog}" /> 
+	</f:entry>
 	<f:validateButton
 	   title="Test Connection" progress="Connecting..."
 	   method="testConnection" with="url,username,password" />

--- a/src/main/webapp/help-truncate.html
+++ b/src/main/webapp/help-truncate.html
@@ -1,0 +1,4 @@
+<div>
+	The flag of truncating the Console Log data. This field
+	is responsible for lowering the data sent to SpiraTest.
+</div>


### PR DESCRIPTION
Hello, Inflectra team / contributors,

I decided to introduce an improvement to the existing Jenkins integration plugin. Currently, I'm facing the issue of getting the BUILDS table filled with full build console logs, so I have added the global configuration flag for excluding the logs from the build description. 
This might not be the only possible solution, as firstly I added the log truncating flag to the job configuration.
I'd like to get your advice on the possible solution which could be accepted by you. 

Best wishes,
Kirils.