### PR TITLE
Enable incrementals and CD versioning (JEP-229)

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+    <extension>
+        <groupId>io.jenkins.tools.incrementals</groupId>
+        <artifactId>git-changelist-maven-extension</artifactId>
+        <version>1.8</version>
+    </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,3 @@
+-Pconsume-incrementals
+-Pmight-produce-incrementals
+-Dchangelist.format=%d.v%s

--- a/pom.xml
+++ b/pom.xml
@@ -12,10 +12,11 @@
 
     <groupId>com.inflectra.spiratest.plugins</groupId>
     <artifactId>inflectra-spira-integration</artifactId>
-    <version>4.0.2-SNAPSHOT</version>
+    <version>${changelist}</version>
 
     <packaging>hpi</packaging>
     <properties>
+        <changelist>999999-SNAPSHOT</changelist>
         <jenkins.version>2.462.3</jenkins.version>
         <additionalparam>-Xdoclint:none</additionalparam>
         <enforcer.skip>true</enforcer.skip>


### PR DESCRIPTION
Enable continuous delivery per [JEP-229](https://github.com/jenkinsci/jep/blob/master/jep/229/README.adoc) so releases are published automatically from GitHub Actions.

Changes:
- Add `.mvn/extensions.xml` with git-changelist-maven-extension
- Add `.mvn/maven.config` with incrementals profiles and changelist format
- Update `pom.xml` version to `${changelist}` / `999999-SNAPSHOT`

RPU PR: <!-- paste link to your repository-permissions-updater PR once created -->

### Testing done

- Ran `mvn validate` locally — builds without errors with the new version format
- This is infrastructure/CI configuration only (no runtime code changes), so no functional tests apply
- CD workflow will be validated end-to-end once RPU PR is merged and secrets are provisioned

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

No automated tests — this is CI/CD pipeline configuration. Will be validated when the first automated release triggers successfully after RPU merge.
